### PR TITLE
Update To _SceneDelegate.swift

### DIFF
--- a/Classes/Controllers/BaseApp/_SceneDelegate.swift
+++ b/Classes/Controllers/BaseApp/_SceneDelegate.swift
@@ -60,6 +60,17 @@ class _SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
     }
     
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+         guard let url = URLContexts.first?.url else {
+             return
+         }
+         let _ = BaseApp.shared.lifecycle?._openURLSourceAppAnnotation?(
+             url,
+             nil,
+             [UIApplication.OpenURLOptionsKey.annotation]
+         )
+     }
+    
     func windowScene(_ windowScene: UIWindowScene, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
         BaseApp.shared.shortcuts
             .first { $0.item.type == shortcutItem.type }?


### PR DESCRIPTION
  func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>)
is necessary for Lifecycle.openURL(_ handler: @escaping (_ url: URL, _ sourceApplication: String?, _ annotation: Any) -> Bool) -> Self
to work properly