### PR TITLE
Collection support for disabling scroll.

### DIFF
--- a/Classes/Views/Not-MacOS/Collection.swift
+++ b/Classes/Views/Not-MacOS/Collection.swift
@@ -199,7 +199,13 @@ public class UCollection: UView, UICollectionViewDataSource {
         collectionView.alwaysBounceVertical = value
         return self
     }
-    
+
+    @discardableResult
+    public func scrollEnabled(_ value: Bool = true) -> Self {
+        collectionView.isScrollEnabled = value
+        return self
+    }
+
     // MARK: Delegate
     
     @discardableResult


### PR DESCRIPTION
To support `CollectionView` self sizing to fit its content - `isScrollEnabled` needs to be disabled. 